### PR TITLE
BRLC-contracts version 1.0.0

### DIFF
--- a/contracts/access-control/BlacklistableUpgradeable.sol
+++ b/contracts/access-control/BlacklistableUpgradeable.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IBlacklistable } from "../interfaces/IBlacklistable.sol";
+
+/**
+ * @title BlacklistableUpgradeable base contract
+ * @author CloudWalk Inc.
+ * @dev Allows to blacklist and unblacklist accounts using the {BLACKLISTER_ROLE} role.
+ *
+ * This contract is used through inheritance. It makes available the modifier `notBlacklisted`,
+ * which can be applied to functions to restrict their usage to not blacklisted accounts only.
+ */
+abstract contract BlacklistableUpgradeable is AccessControlUpgradeable, IBlacklistable {
+    /// @dev The role of the blacklister that is allowed to blacklist and unblacklist accounts.
+    bytes32 public constant BLACKLISTER_ROLE = keccak256("BLACKLISTER_ROLE");
+
+    /// @dev Mapping of presence in the blacklist for a given address.
+    mapping(address => bool) private _blacklisted;
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The account is blacklisted.
+    error BlacklistedAccount(address account);
+
+    // -------------------- Modifiers --------------------------------
+
+    /**
+     * @dev Throws if called by a blacklisted account.
+     * @param account The address to check for presence in the blacklist.
+     */
+    modifier notBlacklisted(address account) {
+        if (_blacklisted[account]) {
+            revert BlacklistedAccount(account);
+        }
+        _;
+    }
+
+    // -------------------- Functions --------------------------------
+
+    /**
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function __Blacklistable_init(bytes32 blacklisterRoleAdmin) internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __AccessControl_init_unchained();
+
+        __Blacklistable_init_unchained(blacklisterRoleAdmin);
+    }
+
+    /**
+     * @dev The unchained internal initializer of the upgradable contract.
+     *
+     * See {BlacklistableUpgradeable-__Blacklistable_init}.
+     */
+    function __Blacklistable_init_unchained(bytes32 blacklisterRoleAdmin) internal onlyInitializing {
+        _setRoleAdmin(BLACKLISTER_ROLE, blacklisterRoleAdmin);
+    }
+
+    /**
+     * @dev Adds an account to the blacklist.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {BLACKLISTER_ROLE} role.
+     *
+     * Emits a {Blacklisted} event.
+     *
+     * @param account The address to blacklist.
+     */
+    function blacklist(address account) public onlyRole(BLACKLISTER_ROLE) {
+        if (_blacklisted[account]) {
+            return;
+        }
+
+        _blacklisted[account] = true;
+
+        emit Blacklisted(account);
+    }
+
+    /**
+     * @dev Removes an account from the blacklist.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {BLACKLISTER_ROLE} role.
+     *
+     * Emits an {UnBlacklisted} event.
+     *
+     * @param account The address to remove from the blacklist.
+     */
+    function unBlacklist(address account) public onlyRole(BLACKLISTER_ROLE) {
+        if (!_blacklisted[account]) {
+            return;
+        }
+
+        _blacklisted[account] = false;
+
+        emit UnBlacklisted(account);
+    }
+
+    /**
+     * @dev Adds the message sender to the blacklist.
+     *
+     * Emits a {SelfBlacklisted} event.
+     * Emits a {Blacklisted} event.
+     */
+    function selfBlacklist() public {
+        address sender = _msgSender();
+
+        if (_blacklisted[sender]) {
+            return;
+        }
+
+        _blacklisted[sender] = true;
+
+        emit SelfBlacklisted(sender);
+        emit Blacklisted(sender);
+    }
+
+    /**
+     * @dev Checks if an account is blacklisted.
+     * @param account The address to check for presence in the blacklist.
+     * @return True if the account is present in the blacklist.
+     */
+    function isBlacklisted(address account) public view returns (bool) {
+        return _blacklisted[account];
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[49] private __gap;
+}

--- a/contracts/access-control/PausableExtUpgradeable.sol
+++ b/contracts/access-control/PausableExtUpgradeable.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import { IPausable } from "../interfaces/IPausable.sol";
+
+/**
+ * @title PausableExtUpgradeable base contract
+ * @author CloudWalk Inc.
+ * @dev Extends the OpenZeppelin's {PausableUpgradeable} contract by adding the {PAUSER_ROLE} role.
+ *
+ * This contract is used through inheritance. It introduces the {PAUSER_ROLE} role that is allowed to
+ * trigger the paused or unpaused state of the contract that is inherited from this one.
+ */
+abstract contract PausableExtUpgradeable is AccessControlUpgradeable, PausableUpgradeable, IPausable {
+    /// @dev The role of pauser that is allowed to trigger the paused or unpaused state of the contract.
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    // -------------------- Functions --------------------------------
+
+    /**
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function __PausableExt_init(bytes32 pauserRoleAdmin) internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __AccessControl_init_unchained();
+        __Pausable_init_unchained();
+
+        __PausableExt_init_unchained(pauserRoleAdmin);
+    }
+
+    /**
+     * @dev The unchained internal initializer of the upgradable contract.
+     *
+     * See {PausableExtUpgradeable-__PausableExt_init}.
+     */
+    function __PausableExt_init_unchained(bytes32 pauserRoleAdmin) internal onlyInitializing {
+        _setRoleAdmin(PAUSER_ROLE, pauserRoleAdmin);
+    }
+
+    /**
+     * @dev Triggers the paused state of the contract.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {PAUSER_ROLE} role.
+     */
+    function pause() public onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    /**
+     * @dev Triggers the unpaused state of the contract.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {PAUSER_ROLE} role.
+     */
+    function unpause() public onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[50] private __gap;
+}

--- a/contracts/access-control/RescuableUpgradeable.sol
+++ b/contracts/access-control/RescuableUpgradeable.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IRescuable } from "../interfaces/IRescuable.sol";
+
+/**
+ * @title RescuableUpgradeable base contract
+ * @author CloudWalk Inc.
+ * @dev Allows to rescue ERC20 tokens locked up in the contract using the {RESCUER_ROLE} role.
+ *
+ * This contract is used through inheritance. It introduces the {RESCUER_ROLE} role that is allowed to
+ * rescue tokens locked up in the contract that is inherited from this one.
+ */
+abstract contract RescuableUpgradeable is AccessControlUpgradeable, IRescuable {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    /// @dev The role of rescuer that is allowed to rescue tokens locked up in the contract.
+    bytes32 public constant RESCUER_ROLE = keccak256("RESCUER_ROLE");
+
+    // -------------------- Functions --------------------------------
+
+    /**
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function __Rescuable_init(bytes32 rescuerRoleAdmin) internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __AccessControl_init_unchained();
+
+        __Rescuable_init_unchained(rescuerRoleAdmin);
+    }
+
+    /**
+     * @dev The unchained internal initializer of the upgradable contract.
+     *
+     * See {RescuableUpgradeable-__Rescuable_init}.
+     */
+    function __Rescuable_init_unchained(bytes32 rescuerRoleAdmin) internal onlyInitializing {
+        _setRoleAdmin(RESCUER_ROLE, rescuerRoleAdmin);
+    }
+
+    /**
+     * @dev Withdraws ERC20 tokens locked up in the contract.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {RESCUER_ROLE} role.
+     *
+     * @param token The address of the ERC20 token contract.
+     * @param to The address of the recipient of tokens.
+     * @param amount The amount of tokens to withdraw.
+     */
+    function rescueERC20(
+        address token,
+        address to,
+        uint256 amount
+    ) public onlyRole(RESCUER_ROLE) {
+        IERC20Upgradeable(token).safeTransfer(to, amount);
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[50] private __gap;
+}

--- a/contracts/access-control/WhitelistableUpgradeable.sol
+++ b/contracts/access-control/WhitelistableUpgradeable.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { IWhitelistable } from "../interfaces/IWhitelistable.sol";
+
+/**
+ * @title WhitelistableUpgradeable base contract
+ * @author CloudWalk Inc.
+ * @dev Allows to whitelist and unwhitelist accounts using the {WHITELISTER_ROLE} role.
+ *
+ * This contract is used through inheritance. It makes available the modifier `onlyWhitelisted`,
+ * which can be applied to functions to restrict their usage to whitelisted accounts only.
+ */
+abstract contract WhitelistableUpgradeable is AccessControlUpgradeable, IWhitelistable {
+    /// @dev The role of the whitelister that is allowed to whitelist and unwhitelist accounts.
+    bytes32 public constant WHITELISTER_ROLE = keccak256("WHITELISTER_ROLE");
+
+    /// @dev Mapping of presence in the whitelist for a given address.
+    mapping(address => bool) private _whitelisted;
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The account is not whitelisted.
+    error NotWhitelistedAccount(address account);
+
+    // -------------------- Modifiers --------------------------------
+
+    /**
+     * @dev Throws if called by not a whitelisted account.
+     * @param account The address to check for presence in the whitelist.
+     */
+    modifier onlyWhitelisted(address account) {
+        if (!_whitelisted[account]) {
+            revert NotWhitelistedAccount(account);
+        }
+        _;
+    }
+
+    // -------------------- Functions --------------------------------
+
+    /**
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function __Whitelistable_init(bytes32 whitelisterRoleAdmin) internal onlyInitializing {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __AccessControl_init_unchained();
+
+        __Whitelistable_init_unchained(whitelisterRoleAdmin);
+    }
+
+    /**
+     * @dev The unchained internal initializer of the upgradable contract.
+     *
+     * See {WhitelistableUpgradeable-__Whitelistable_init}.
+     */
+    function __Whitelistable_init_unchained(bytes32 whitelisterRoleAdmin) internal onlyInitializing {
+        _setRoleAdmin(WHITELISTER_ROLE, whitelisterRoleAdmin);
+    }
+
+    /**
+     * @dev Adds an account to the whitelist.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {WHITELISTER_ROLE} role.
+     *
+     * Emits a {Whitelisted} event.
+     *
+     * @param account The address to whitelist.
+     */
+    function whitelist(address account) public onlyRole(WHITELISTER_ROLE) {
+        if (_whitelisted[account]) {
+            return;
+        }
+
+        _whitelisted[account] = true;
+
+        emit Whitelisted(account);
+    }
+
+    /**
+     * @dev Removes an account from the whitelist.
+     *
+     * Requirements:
+     *
+     * - The caller must have the {WHITELISTER_ROLE} role.
+     *
+     * Emits an {UnWhitelisted} event.
+     *
+     * @param account The address to remove from the whitelist.
+     */
+    function unWhitelist(address account) public onlyRole(WHITELISTER_ROLE) {
+        if (!_whitelisted[account]) {
+            return;
+        }
+
+        _whitelisted[account] = false;
+
+        emit UnWhitelisted(account);
+    }
+
+    /**
+     * @dev Checks if an account is whitelisted.
+     * @param account The address to check for presence in the whitelist.
+     * @return True if the account is present in the whitelist.
+     */
+    function isWhitelisted(address account) public view returns (bool) {
+        return _whitelisted[account];
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[49] private __gap;
+}

--- a/contracts/access-ownable/BlacklistableUpgradeable.sol
+++ b/contracts/access-ownable/BlacklistableUpgradeable.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { IBlacklistable } from "../interfaces/IBlacklistable.sol";
+
+/**
+ * @title BlacklistableUpgradeable base contract
+ * @author CloudWalk Inc.
+ * @dev Allows to blacklist and unblacklist accounts using the `blacklister` account.
+ *
+ * This contract is used through inheritance. It makes available the modifier `notBlacklisted`,
+ * which can be applied to functions to restrict their usage to not blacklisted accounts only.
+ */
+abstract contract BlacklistableUpgradeable is OwnableUpgradeable, IBlacklistable {
+    /// @dev The address of the blacklister that is allowed to blacklist and unblacklist accounts.
+    address private _blacklister;
+
+    /// @dev Mapping of presence in the blacklist for a given address.
+    mapping(address => bool) private _blacklisted;
+
+    // -------------------- Events -----------------------------------
+
+    /// @dev Emitted when the blacklister is changed.
+    event BlacklisterChanged(address indexed newBlacklister);
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The message sender is not a blacklister.
+    error UnauthorizedBlacklister(address account);
+
+    /// @dev The account is blacklisted.
+    error BlacklistedAccount(address account);
+
+    // -------------------- Modifiers --------------------------------
+
+    /**
+     * @dev Throws if called by any account other than the blacklister.
+     */
+    modifier onlyBlacklister() {
+        if (_msgSender() != _blacklister) {
+            revert UnauthorizedBlacklister(_msgSender());
+        }
+        _;
+    }
+
+    /**
+     * @dev Throws if called by a blacklisted account.
+     * @param account The address to check for presence in the blacklist.
+     */
+    modifier notBlacklisted(address account) {
+        if (_blacklisted[account]) {
+            revert BlacklistedAccount(account);
+        }
+        _;
+    }
+
+    // -------------------- Functions --------------------------------
+
+    /**
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function __Blacklistable_init() internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+
+        __Blacklistable_init_unchained();
+    }
+
+    /**
+     * @dev The unchained internal initializer of the upgradable contract.
+     *
+     * See {BlacklistableUpgradeable-__Blacklistable_init}.
+     */
+    function __Blacklistable_init_unchained() internal onlyInitializing {}
+
+    /**
+     * @dev Adds an account to the blacklist.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the blacklister account.
+     *
+     * Emits a {Blacklisted} event.
+     *
+     * @param account The address to blacklist.
+     */
+    function blacklist(address account) public onlyBlacklister {
+        if (_blacklisted[account]) {
+            return;
+        }
+
+        _blacklisted[account] = true;
+
+        emit Blacklisted(account);
+    }
+
+    /**
+     * @dev Removes an account from the blacklist.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the blacklister account.
+     *
+     * Emits an {UnBlacklisted} event.
+     *
+     * @param account The address to remove from the blacklist.
+     */
+    function unBlacklist(address account) public onlyBlacklister {
+        if (!_blacklisted[account]) {
+            return;
+        }
+
+        _blacklisted[account] = false;
+
+        emit UnBlacklisted(account);
+    }
+
+    /**
+     * @dev Adds the message sender to the blacklist.
+     *
+     * Emits a {SelfBlacklisted} event.
+     * Emits a {Blacklisted} event.
+     */
+    function selfBlacklist() public {
+        address sender = _msgSender();
+
+        if (_blacklisted[sender]) {
+            return;
+        }
+
+        _blacklisted[sender] = true;
+
+        emit SelfBlacklisted(sender);
+        emit Blacklisted(sender);
+    }
+
+    /**
+     * @dev Updates the blacklister address.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract owner.
+     *
+     * Emits a {BlacklisterChanged} event.
+     *
+     * @param newBlacklister The address of a new blacklister.
+     */
+    function setBlacklister(address newBlacklister) public onlyOwner {
+        if (_blacklister == newBlacklister) {
+            return;
+        }
+
+        _blacklister = newBlacklister;
+
+        emit BlacklisterChanged(_blacklister);
+    }
+
+    /**
+     * @dev Returns the blacklister address.
+     */
+    function blacklister() public view virtual returns (address) {
+        return _blacklister;
+    }
+
+    /**
+     * @dev Checks if an account is blacklisted.
+     * @param account The address to check for presence in the blacklist.
+     * @return True if the account is present in the blacklist.
+     */
+    function isBlacklisted(address account) public view returns (bool) {
+        return _blacklisted[account];
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[48] private __gap;
+}

--- a/contracts/access-ownable/PausableExtUpgradeable.sol
+++ b/contracts/access-ownable/PausableExtUpgradeable.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import { IPausable } from "../interfaces/IPausable.sol";
+
+/**
+ * @title PausableExtUpgradeable base contract
+ * @author CloudWalk Inc.
+ * @dev Extends the OpenZeppelin's {PausableUpgradeable} contract by adding the `pauser` account.
+ *
+ * This contract is used through inheritance. It introduces the `pauser` role that is allowed to
+ * trigger the paused or unpaused state of the contract that is inherited from this one.
+ */
+abstract contract PausableExtUpgradeable is OwnableUpgradeable, PausableUpgradeable, IPausable {
+    /// @dev The address of the pauser that is allowed to trigger the paused or unpaused state of the contract.
+    address private _pauser;
+
+    // -------------------- Events -----------------------------------
+
+    /// @dev Emitted when the pauser is changed.
+    event PauserChanged(address indexed pauser);
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The message sender is not a pauser.
+    error UnauthorizedPauser(address account);
+
+    // -------------------- Modifiers --------------------------------
+
+    /**
+     * @dev Throws if called by any account other than the pauser.
+     */
+    modifier onlyPauser() {
+        if (_msgSender() != _pauser) {
+            revert UnauthorizedPauser(_msgSender());
+        }
+        _;
+    }
+
+    // -------------------- Functions --------------------------------
+
+    /**
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function __PausableExt_init() internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __Pausable_init_unchained();
+
+        __PausableExt_init_unchained();
+    }
+
+    /**
+     * @dev The unchained internal initializer of the upgradable contract.
+     *
+     * See {PausableExtUpgradeable-__PausableExt_init}.
+     */
+    function __PausableExt_init_unchained() internal onlyInitializing {}
+
+    /**
+     * @dev Triggers the paused state of the contract.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract pauser.
+     */
+    function pause() public onlyPauser {
+        _pause();
+    }
+
+    /**
+     * @dev Triggers the unpaused state of the contract.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract pauser.
+     */
+    function unpause() public onlyPauser {
+        _unpause();
+    }
+
+    /**
+     * @dev Updates the pauser address.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract owner.
+     *
+     * Emits a {PauserChanged} event.
+     *
+     * @param newPauser The address of a new pauser.
+     */
+    function setPauser(address newPauser) public onlyOwner {
+        if (_pauser == newPauser) {
+            return;
+        }
+
+        _pauser = newPauser;
+
+        emit PauserChanged(newPauser);
+    }
+
+    /**
+     * @dev Returns the pauser address.
+     */
+    function pauser() public view virtual returns (address) {
+        return _pauser;
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[49] private __gap;
+}

--- a/contracts/access-ownable/RescuableUpgradeable.sol
+++ b/contracts/access-ownable/RescuableUpgradeable.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { IRescuable } from "../interfaces/IRescuable.sol";
+
+/**
+ * @title RescuableUpgradeable base contract
+ * @author CloudWalk Inc.
+ * @dev Allows to rescue ERC20 tokens locked up in the contract using the `rescuer` account.
+ *
+ * This contract is used through inheritance. It introduces the `rescuer` role that is allowed to
+ * rescue tokens locked up in the contract that is inherited from this one.
+ */
+abstract contract RescuableUpgradeable is OwnableUpgradeable, IRescuable {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    /// @dev The address of the rescuer that is allowed to rescue tokens locked up in the contract.
+    address private _rescuer;
+
+    // -------------------- Events -----------------------------------
+
+    /// @dev Emitted when the rescuer is changed.
+    event RescuerChanged(address indexed newRescuer);
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The message sender is not a rescuer.
+    error UnauthorizedRescuer(address account);
+
+    // -------------------- Modifiers --------------------------------
+
+    /**
+     * @dev Throws if called by any account other than the rescuer.
+     */
+    modifier onlyRescuer() {
+        if (_msgSender() != _rescuer) {
+            revert UnauthorizedRescuer(_msgSender());
+        }
+        _;
+    }
+
+    // -------------------- Functions --------------------------------
+
+    /**
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function __Rescuable_init() internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+
+        __Rescuable_init_unchained();
+    }
+
+    /**
+     * @dev The unchained internal initializer of the upgradable contract.
+     *
+     * See {RescuableUpgradeable-__Rescuable_init}.
+     */
+    function __Rescuable_init_unchained() internal onlyInitializing {}
+
+    /**
+     * @dev Withdraws ERC20 tokens locked up in the contract.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the rescuer account.
+     *
+     * @param token The address of the ERC20 token contract.
+     * @param to The address of the recipient of tokens.
+     * @param amount The amount of tokens to withdraw.
+     */
+    function rescueERC20(
+        address token,
+        address to,
+        uint256 amount
+    ) public onlyRescuer {
+        IERC20Upgradeable(token).safeTransfer(to, amount);
+    }
+
+    /**
+     * @dev Updates the rescuer address.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract owner.
+     *
+     * Emits a {RescuerChanged} event.
+     *
+     * @param newRescuer The address of a new rescuer.
+     */
+    function setRescuer(address newRescuer) public onlyOwner {
+        if (_rescuer == newRescuer) {
+            return;
+        }
+
+        _rescuer = newRescuer;
+
+        emit RescuerChanged(newRescuer);
+    }
+
+    /**
+     * @dev Returns the rescuer address.
+     */
+    function rescuer() public view virtual returns (address) {
+        return _rescuer;
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[49] private __gap;
+}

--- a/contracts/access-ownable/WhitelistableUpgradeable.sol
+++ b/contracts/access-ownable/WhitelistableUpgradeable.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { IWhitelistable } from "../interfaces/IWhitelistable.sol";
+
+/**
+ * @title WhitelistableUpgradeable base contract
+ * @author CloudWalk Inc.
+ * @dev Allows to whitelist and unwhitelist accounts using the `whitelister` account.
+ *
+ * This contract is used through inheritance. It makes available the modifier `onlyWhitelisted`,
+ * which can be applied to functions to restrict their usage to whitelisted accounts only.
+ */
+abstract contract WhitelistableUpgradeable is OwnableUpgradeable, IWhitelistable {
+    /// @dev The address of the whitelister that is allowed to whitelist and unwhitelist accounts.
+    address private _whitelister;
+
+    /// @dev Mapping of presence in the whitelist for a given address.
+    mapping(address => bool) private _whitelisted;
+
+    // -------------------- Events -----------------------------------
+
+    /// @dev Emitted when the whitelister is changed.
+    event WhitelisterChanged(address indexed newWhitelister);
+
+    // -------------------- Errors -----------------------------------
+
+    /// @dev The message sender is not a whitelister.
+    error UnauthorizedWhitelister(address account);
+
+    /// @dev The account is not whitelisted.
+    error NotWhitelistedAccount(address account);
+
+    // -------------------- Modifiers --------------------------------
+
+    /**
+     * @dev Throws if called by any account other than the whitelister.
+     */
+    modifier onlyWhitelister() {
+        if (_msgSender() != _whitelister) {
+            revert UnauthorizedWhitelister(_msgSender());
+        }
+        _;
+    }
+
+    /**
+     * @dev Throws if called by not a whitelisted account.
+     * @param account The address to check for presence in the whitelist.
+     */
+    modifier onlyWhitelisted(address account) {
+        if (!_whitelisted[account]) {
+            revert NotWhitelistedAccount(account);
+        }
+        _;
+    }
+
+    // -------------------- Functions --------------------------------
+
+    /**
+     * @dev The internal initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function __Whitelistable_init() internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+
+        __Whitelistable_init_unchained();
+    }
+
+    /**
+     * @dev The unchained internal initializer of the upgradable contract.
+     *
+     * See {WhitelistableUpgradeable-__Whitelistable_init}.
+     */
+    function __Whitelistable_init_unchained() internal onlyInitializing {}
+
+    /**
+     * @dev Adds an account to the whitelist.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the whitelister account.
+     *
+     * Emits a {Whitelisted} event.
+     *
+     * @param account The address to whitelist.
+     */
+    function whitelist(address account) public onlyWhitelister {
+        if (_whitelisted[account]) {
+            return;
+        }
+
+        _whitelisted[account] = true;
+
+        emit Whitelisted(account);
+    }
+
+    /**
+     * @dev Removes an account from the whitelist.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the whitelister account.
+     *
+     * Emits an {UnWhitelisted} event.
+     *
+     * @param account The address to remove from the whitelist.
+     */
+    function unWhitelist(address account) public onlyWhitelister {
+        if (!_whitelisted[account]) {
+            return;
+        }
+
+        _whitelisted[account] = false;
+
+        emit UnWhitelisted(account);
+    }
+
+    /**
+     * @dev Updates the whitelister address.
+     *
+     * Requirements:
+     *
+     * - Can only be called by the contract owner.
+     *
+     * Emits a {WhitelisterChanged} event.
+     *
+     * @param newWhitelister The address of a new whitelister.
+     */
+    function setWhitelister(address newWhitelister) public onlyOwner {
+        if (_whitelister == newWhitelister) {
+            return;
+        }
+
+        _whitelister = newWhitelister;
+
+        emit WhitelisterChanged(_whitelister);
+    }
+
+    /**
+     * @dev Returns the whitelister address.
+     */
+    function whitelister() public view virtual returns (address) {
+        return _whitelister;
+    }
+
+    /**
+     * @dev Checks if an account is whitelisted.
+     * @param account The address to check for presence in the whitelist.
+     * @return True if the account is present in the whitelist.
+     */
+    function isWhitelisted(address account) public view returns (bool) {
+        return _whitelisted[account];
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     */
+    uint256[48] private __gap;
+}

--- a/contracts/mocks/access-control/BlacklistableUpgradeableMock.sol
+++ b/contracts/mocks/access-control/BlacklistableUpgradeableMock.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { BlacklistableUpgradeable } from "../../access-control/BlacklistableUpgradeable.sol";
+
+/**
+ * @title BlacklistableUpgradeableMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {BlacklistableUpgradeable} contract for test purposes.
+ */
+contract BlacklistableUpgradeableMock is BlacklistableUpgradeable {
+    /// @dev The role of this contract owner.
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @dev Emitted when a test function of the `notBlacklisted` modifier executes successfully.
+    event TestNotBlacklistedModifierSucceeded();
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function initialize() public initializer {
+        _setupRole(OWNER_ROLE, _msgSender());
+        __Blacklistable_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev Needed to check that the initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize() public {
+        __Blacklistable_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev Needed to check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __Blacklistable_init_unchained(OWNER_ROLE);
+    }
+
+    /**
+     * @dev Checks the execution of the {notBlacklisted} modifier.
+     * If that modifier executed without reverting emits an event {TestNotBlacklistedModifierSucceeded}.
+     */
+    function testNotBlacklistedModifier() external notBlacklisted(_msgSender()) {
+        emit TestNotBlacklistedModifierSucceeded();
+    }
+}

--- a/contracts/mocks/access-control/PausableExtUpgradeableMock.sol
+++ b/contracts/mocks/access-control/PausableExtUpgradeableMock.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { PausableExtUpgradeable } from "../../access-control/PausableExtUpgradeable.sol";
+
+/**
+ * @title PausableExtUpgradeableMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {PausableExtUpgradeable} contract for test purposes.
+ */
+contract PausableExtUpgradeableMock is PausableExtUpgradeable {
+    /// @dev The role of this contract owner.
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function initialize() public initializer {
+        _setupRole(OWNER_ROLE, _msgSender());
+        __PausableExt_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev Needed to check that the initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize() public {
+        __PausableExt_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev Needed to check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __PausableExt_init_unchained(OWNER_ROLE);
+    }
+}

--- a/contracts/mocks/access-control/RescuableUpgradeableMock.sol
+++ b/contracts/mocks/access-control/RescuableUpgradeableMock.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { RescuableUpgradeable } from "../../access-control/RescuableUpgradeable.sol";
+
+/**
+ * @title RescuableUpgradeableMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {RescuableUpgradeable} contract for test purposes.
+ */
+contract RescuableUpgradeableMock is RescuableUpgradeable {
+    /// @dev The role of this contract owner.
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function initialize() public initializer {
+        _setupRole(OWNER_ROLE, _msgSender());
+        __Rescuable_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev Needed to check that the initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize() public {
+        __Rescuable_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev Needed to check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __Rescuable_init_unchained(OWNER_ROLE);
+    }
+}

--- a/contracts/mocks/access-control/WhitelistableUpgradeableMock.sol
+++ b/contracts/mocks/access-control/WhitelistableUpgradeableMock.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { WhitelistableUpgradeable } from "../../access-control/WhitelistableUpgradeable.sol";
+
+/**
+ * @title WhitelistableUpgradeableMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {WhitelistableUpgradeable} contract for test purposes.
+ */
+contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
+    /// @dev The role of this contract owner.
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @dev Emitted when a test function of the `onlyWhitelisted` modifier executes successfully.
+    event TestOnlyWhitelistedModifierSucceeded();
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function initialize() public initializer {
+        _setupRole(OWNER_ROLE, _msgSender());
+        __Whitelistable_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev Needed to check that the initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize() public {
+        __Whitelistable_init(OWNER_ROLE);
+    }
+
+    /**
+     * @dev Needed to check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __Whitelistable_init_unchained(OWNER_ROLE);
+    }
+
+    /**
+     * @dev Checks the execution of the {onlyWhitelisted} modifier.
+     * If that modifier executed without reverting emits an event {TestOnlyWhitelistedModifierSucceeded}.
+     */
+    function testOnlyWhitelistedModifier() external onlyWhitelisted(_msgSender()) {
+        emit TestOnlyWhitelistedModifierSucceeded();
+    }
+}

--- a/contracts/mocks/access-ownable/BlacklistableUpgradeableMock.sol
+++ b/contracts/mocks/access-ownable/BlacklistableUpgradeableMock.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { BlacklistableUpgradeable } from "../../access-ownable/BlacklistableUpgradeable.sol";
+
+/**
+ * @title BlacklistableUpgradeableMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {BlacklistableUpgradeable} contract for test purposes.
+ */
+contract BlacklistableUpgradeableMock is BlacklistableUpgradeable {
+    /// @dev Emitted when a test function of the `notBlacklisted` modifier executes successfully.
+    event TestNotBlacklistedModifierSucceeded();
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function initialize() public initializer {
+        __Blacklistable_init();
+    }
+
+    /**
+     * @dev Needed to check that the initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize() public {
+        __Blacklistable_init();
+    }
+
+    /**
+     * @dev Needed to check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __Blacklistable_init_unchained();
+    }
+
+    /**
+     * @dev Checks the execution of the {notBlacklisted} modifier.
+     * If that modifier executed without reverting emits an event {TestNotBlacklistedModifierSucceeded}.
+     */
+    function testNotBlacklistedModifier() external notBlacklisted(_msgSender()) {
+        emit TestNotBlacklistedModifierSucceeded();
+    }
+}

--- a/contracts/mocks/access-ownable/PausableExtUpgradeableMock.sol
+++ b/contracts/mocks/access-ownable/PausableExtUpgradeableMock.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { PausableExtUpgradeable } from "../../access-ownable/PausableExtUpgradeable.sol";
+
+/**
+ * @title PausableExtUpgradeableMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {PausableExtUpgradeable} contract for test purposes.
+ */
+contract PausableExtUpgradeableMock is PausableExtUpgradeable {
+    /**
+     * @dev The initialize function of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function initialize() public initializer {
+        __PausableExt_init();
+    }
+
+    /**
+     * @dev Needed to check that the initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize() public {
+        __PausableExt_init();
+    }
+
+    /**
+     * @dev Needed to check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __PausableExt_init_unchained();
+    }
+}

--- a/contracts/mocks/access-ownable/RescuableUpgradeableMock.sol
+++ b/contracts/mocks/access-ownable/RescuableUpgradeableMock.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { RescuableUpgradeable } from "../../access-ownable/RescuableUpgradeable.sol";
+
+/**
+ * @title RescuableUpgradeableMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {RescuableUpgradeable} contract for test purposes.
+ */
+contract RescuableUpgradeableMock is RescuableUpgradeable {
+    /**
+     * @dev The initialize function of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function initialize() public initializer {
+        __Rescuable_init();
+    }
+
+    /**
+     * @dev Needed to check that the initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize() public {
+        __Rescuable_init();
+    }
+
+    /**
+     * @dev Needed to check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __Rescuable_init_unchained();
+    }
+}

--- a/contracts/mocks/access-ownable/WhitelistableUpgradeableMock.sol
+++ b/contracts/mocks/access-ownable/WhitelistableUpgradeableMock.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { WhitelistableUpgradeable } from "../../access-ownable/WhitelistableUpgradeable.sol";
+
+/**
+ * @title WhitelistableUpgradeableMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {WhitelistableUpgradeable} contract for test purposes.
+ */
+contract WhitelistableUpgradeableMock is WhitelistableUpgradeable {
+    /// @dev Emitted when a test function of the `onlyWhitelisted` modifier executes successfully.
+    event TestOnlyWhitelistedModifierSucceeded();
+
+    /**
+     * @dev The initialize function of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     */
+    function initialize() public initializer {
+        __Whitelistable_init();
+    }
+
+    /**
+     * @dev Needed to check that the initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize() public {
+        __Whitelistable_init();
+    }
+
+    /**
+     * @dev Needed to check that the unchained initialize function of the ancestor contract
+     * has the 'onlyInitializing' modifier.
+     */
+    function call_parent_initialize_unchained() public {
+        __Whitelistable_init_unchained();
+    }
+
+    /**
+     * @dev Checks the execution of the {onlyWhitelisted} modifier.
+     * If that modifier executed without reverting emits an event {TestOnlyWhitelistedModifierSucceeded}.
+     */
+    function testOnlyWhitelistedModifier() external onlyWhitelisted(_msgSender()) {
+        emit TestOnlyWhitelistedModifierSucceeded();
+    }
+}

--- a/contracts/mocks/tokens/ERC20UpgradeableMock.sol
+++ b/contracts/mocks/tokens/ERC20UpgradeableMock.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+/**
+ * @title ERC20UpgradeableMock contract
+ * @author CloudWalk Inc.
+ * @dev An implementation of the {ERC20Upgradeable} contract for test purposes.
+ */
+contract ERC20UpgradeableMock is ERC20Upgradeable {
+    /**
+     * @dev The initializer of the upgradable contract.
+     *
+     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     *
+     * @param name_ The name of the token to set for this ERC20-comparable contract.
+     * @param symbol_ The symbol of the token to set for this ERC20-comparable contract.
+     */
+    function initialize(string memory name_, string memory symbol_) public initializer {
+        __ERC20_init(name_, symbol_);
+    }
+
+    /**
+     * @dev Calls the appropriate internal function to mint needed amount of tokens for an account.
+     * @param account The address of an account to mint for.
+     * @param amount The amount of tokens to mint.
+     */
+    function mint(address account, uint256 amount) external returns (bool) {
+        _mint(account, amount);
+        return true;
+    }
+}

--- a/contracts/storage/StoragePlaceholder100.sol
+++ b/contracts/storage/StoragePlaceholder100.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+/**
+ * @title StoragePlaceholder100 base contract
+ * @author CloudWalk Inc.
+ * @dev Reserves 100 storage slots.
+ * Such a storage placeholder contract allows future replacement of it with other contracts
+ * without shifting down storage in the inheritance chain.
+ *
+ * E.g. the following code:
+ * ```
+ * abstract contract StoragePlaceholder100 {
+ *     uint256[100] private __gap;
+ * }
+ *
+ * contract A is B, StoragePlaceholder100, C {
+ *     //Some implementation
+ * }
+ * ```
+ * can be replaced with the following code without a storage shifting issue:
+ * ```
+ * abstract contract StoragePlaceholder50 {
+ *     uint256[50] private __gap;
+ * }
+ *
+ * abstract contract X {
+ *     uint256[50] public values;
+ *     // No more storage variables. Some set of functions should be here.
+ * }
+ *
+ * contract A is B, X, StoragePlaceholder50, C {
+ *     //Some implementation
+ * }
+ * ```
+ */
+abstract contract StoragePlaceholder100 {
+    uint256[100] private __gap;
+}

--- a/contracts/storage/StoragePlaceholder150.sol
+++ b/contracts/storage/StoragePlaceholder150.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+/**
+ * @title StoragePlaceholder150 base contract
+ * @author CloudWalk Inc.
+ * @dev Reserves 150 storage slots.
+ * Such a storage placeholder contract allows future replacement of it with other contracts
+ * without shifting down storage in the inheritance chain.
+ *
+ * E.g. the following code:
+ * ```
+ * abstract contract StoragePlaceholder150 {
+ *     uint256[150] private __gap;
+ * }
+ *
+ * contract A is B, StoragePlaceholder150, C {
+ *     //Some implementation
+ * }
+ * ```
+ * can be replaced with the following code without a storage shifting issue:
+ * ```
+ * abstract contract StoragePlaceholder100 {
+ *     uint256[100] private __gap;
+ * }
+ *
+ * abstract contract X {
+ *     uint256[50] public values;
+ *     // No more storage variables. Some set of functions should be here.
+ * }
+ *
+ * contract A is B, X, StoragePlaceholder100, C {
+ *     //Some implementation
+ * }
+ * ```
+ */
+abstract contract StoragePlaceholder150 {
+    uint256[150] private __gap;
+}

--- a/contracts/storage/StoragePlaceholder200.sol
+++ b/contracts/storage/StoragePlaceholder200.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+/**
+ * @title StoragePlaceholder200 base contract
+ * @author CloudWalk Inc.
+ * @dev Reserves 200 storage slots.
+ * Such a storage placeholder contract allows future replacement of it with other contracts
+ * without shifting down storage in the inheritance chain.
+ *
+ * E.g. the following code:
+ * ```
+ * abstract contract StoragePlaceholder200 {
+ *     uint256[200] private __gap;
+ * }
+ *
+ * contract A is B, StoragePlaceholder200, C {
+ *     //Some implementation
+ * }
+ * ```
+ * can be replaced with the following code without a storage shifting issue:
+ * ```
+ * abstract contract StoragePlaceholder150 {
+ *     uint256[150] private __gap;
+ * }
+ *
+ * abstract contract X {
+ *     uint256[50] public values;
+ *     // No more storage variables. Some set of functions should be here.
+ * }
+ *
+ * contract A is B, X, StoragePlaceholder150, C {
+ *     //Some implementation
+ * }
+ * ```
+ */
+abstract contract StoragePlaceholder200 {
+    uint256[200] private __gap;
+}

--- a/contracts/storage/StoragePlaceholder50.sol
+++ b/contracts/storage/StoragePlaceholder50.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.8;
+
+/**
+ * @title StoragePlaceholder50 base contract
+ * @author CloudWalk Inc.
+ * @dev Reserves 50 storage slots.
+ * Such a storage placeholder contract allows future replacement of it with other contracts
+ * without shifting down storage in the inheritance chain.
+ *
+ * E.g. the following code:
+ * ```
+ * abstract contract StoragePlaceholder50 {
+ *     uint256[50] private __gap;
+ * }
+ *
+ * contract A is B, StoragePlaceholder50, C {
+ *     //Some implementation
+ * }
+ * ```
+ * can be replaced with the following code without a storage shifting issue:
+ * ```
+ * abstract contract StoragePlaceholder25 {
+ *     uint256[25] private __gap;
+ * }
+ *
+ * abstract contract X {
+ *     uint256[25] public values;
+ *     // No more storage variables. Some set of functions should be here.
+ * }
+ *
+ * contract A is B, X, StoragePlaceholder25, C {
+ *     //Some implementation
+ * }
+ * ```
+ */
+abstract contract StoragePlaceholder50 {
+    uint256[50] private __gap;
+}

--- a/test/access-control/BlacklistableUpgradeable.test.ts
+++ b/test/access-control/BlacklistableUpgradeable.test.ts
@@ -1,0 +1,194 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../../test-utils/eth";
+import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'access-control/BlacklistableUpgradeable'", async () => {
+  const EVENT_NAME_BLACKLISTED = "Blacklisted";
+  const EVENT_NAME_SELFBLACKLISTED = "SelfBlacklisted";
+  const EVENT_NAME_TEST_NOT_BLACKLISTED_MODIFIER_SUCCEEDED = "TestNotBlacklistedModifierSucceeded";
+  const EVENT_NAME_UNBLACKLISTED = "UnBlacklisted";
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+
+  const REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED = "BlacklistedAccount";
+
+  const ownerRole: string = ethers.utils.id("OWNER_ROLE");
+  const blacklisterRole: string = ethers.utils.id("BLACKLISTER_ROLE");
+
+  let blacklistableMockFactory: ContractFactory;
+
+  let deployer: SignerWithAddress;
+  let blacklister: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  before(async () => {
+    [deployer, blacklister, user] = await ethers.getSigners();
+    blacklistableMockFactory = await ethers.getContractFactory(
+      "contracts/mocks/access-control/BlacklistableUpgradeableMock.sol:BlacklistableUpgradeableMock");
+  });
+
+  async function deployBlacklistableMock(): Promise<{ blacklistableMock: Contract }> {
+    const blacklistableMock: Contract = await upgrades.deployProxy(blacklistableMockFactory);
+    await blacklistableMock.deployed();
+
+    return { blacklistableMock };
+  }
+
+  async function deployAndConfigureBlacklistableMock(): Promise<{ blacklistableMock: Contract }> {
+    const { blacklistableMock } = await deployBlacklistableMock();
+    await proveTx(blacklistableMock.grantRole(blacklisterRole, blacklister.address));
+    return { blacklistableMock };
+  }
+
+  describe("Initializers", async () => {
+    it("The external initializer configures the contract as expected", async () => {
+      const { blacklistableMock } = await setUpFixture(deployBlacklistableMock);
+
+      // The roles
+      expect(await blacklistableMock.OWNER_ROLE()).to.equal(ownerRole);
+      expect(await blacklistableMock.BLACKLISTER_ROLE()).to.equal(blacklisterRole);
+
+      // The role admins
+      expect(await blacklistableMock.getRoleAdmin(ownerRole)).to.equal(ethers.constants.HashZero);
+      expect(await blacklistableMock.getRoleAdmin(blacklisterRole)).to.equal(ownerRole);
+
+      // The deployer should have the owner role, but not the other roles
+      expect(await blacklistableMock.hasRole(ownerRole, deployer.address)).to.equal(true);
+      expect(await blacklistableMock.hasRole(blacklisterRole, deployer.address)).to.equal(false);
+    });
+
+    it("The external initializer is reverted if it is called a second time", async () => {
+      const { blacklistableMock } = await setUpFixture(deployBlacklistableMock);
+      await expect(
+        blacklistableMock.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("The internal initializer is reverted if it is called outside the init process", async () => {
+      const { blacklistableMock } = await setUpFixture(deployBlacklistableMock);
+      await expect(
+        blacklistableMock.call_parent_initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+
+    it("The internal unchained initializer is reverted if it is called outside the init process", async () => {
+      const { blacklistableMock } = await setUpFixture(deployBlacklistableMock);
+      await expect(
+        blacklistableMock.call_parent_initialize_unchained()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+  });
+
+  describe("Function 'blacklist()'", async () => {
+    it("Executes as expected and emits the correct event if it is called by a blacklister", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+      expect(await blacklistableMock.isBlacklisted(user.address)).to.equal(false);
+
+      await expect(
+        blacklistableMock.connect(blacklister).blacklist(user.address)
+      ).to.emit(
+        blacklistableMock,
+        EVENT_NAME_BLACKLISTED
+      ).withArgs(user.address);
+      expect(await blacklistableMock.isBlacklisted(user.address)).to.equal(true);
+
+      // Second call with the same argument should not emit an event
+      await expect(
+        blacklistableMock.connect(blacklister).blacklist(user.address)
+      ).not.to.emit(blacklistableMock, EVENT_NAME_BLACKLISTED);
+    });
+  });
+
+  it("Is reverted if it is called by an account without the blacklister role", async () => {
+    const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+    await expect(
+      blacklistableMock.blacklist(user.address)
+    ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, blacklisterRole));
+  });
+
+  describe("Function 'unBlacklist()'", async () => {
+    it("Executes as expected and emits the correct event if it is called by a blacklister", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+      await proveTx(blacklistableMock.connect(blacklister).blacklist(user.address));
+      expect(await blacklistableMock.isBlacklisted(user.address)).to.equal(true);
+
+      await expect(
+        blacklistableMock.connect(blacklister).unBlacklist(user.address)
+      ).to.emit(
+        blacklistableMock,
+        EVENT_NAME_UNBLACKLISTED
+      ).withArgs(user.address);
+      expect(await blacklistableMock.isBlacklisted(user.address)).to.equal(false);
+
+      // The second call with the same argument should not emit an event
+      await expect(
+        blacklistableMock.connect(blacklister).unBlacklist(user.address)
+      ).not.to.emit(blacklistableMock, EVENT_NAME_UNBLACKLISTED);
+    });
+
+    it("Is reverted if it is called by an account without the blacklister role", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+      await expect(
+        blacklistableMock.unBlacklist(user.address)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, blacklisterRole));
+    });
+  });
+
+  describe("Function 'selfBlacklist()'", async () => {
+    it("Executes as expected and emits the correct events if it is called by any account", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+      expect(await blacklistableMock.isBlacklisted(user.address)).to.equal(false);
+
+      await expect(
+        blacklistableMock.connect(user).selfBlacklist()
+      ).to.emit(
+        blacklistableMock,
+        EVENT_NAME_BLACKLISTED
+      ).withArgs(
+        user.address
+      ).and.to.emit(
+        blacklistableMock,
+        EVENT_NAME_SELFBLACKLISTED
+      ).withArgs(
+        user.address
+      );
+      expect(await blacklistableMock.isBlacklisted(user.address)).to.equal(true);
+
+      // Second call should not emit an event
+      await expect(
+        blacklistableMock.connect(user).selfBlacklist()
+      ).not.to.emit(blacklistableMock, EVENT_NAME_SELFBLACKLISTED);
+    });
+  });
+
+  describe("Modifier 'notBlacklisted'", async () => {
+    it("Reverts the target function if the caller is blacklisted", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+
+      await proveTx(blacklistableMock.connect(blacklister).blacklist(deployer.address));
+      await expect(
+        blacklistableMock.testNotBlacklistedModifier()
+      ).to.be.revertedWithCustomError(blacklistableMock, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Does not revert the target function if the caller is not blacklisted", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+      await expect(
+        blacklistableMock.connect(user).testNotBlacklistedModifier()
+      ).to.emit(blacklistableMock, EVENT_NAME_TEST_NOT_BLACKLISTED_MODIFIER_SUCCEEDED);
+    });
+  });
+});

--- a/test/access-control/PausableExtUpgradeable.test.ts
+++ b/test/access-control/PausableExtUpgradeable.test.ts
@@ -1,0 +1,133 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../../test-utils/eth";
+import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'access-control/PausableExtUpgradeable'", async () => {
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+
+  const ownerRole: string = ethers.utils.id("OWNER_ROLE");
+  const pauserRole: string = ethers.utils.id("PAUSER_ROLE");
+
+  let pausableExtMockFactory: ContractFactory;
+
+  let deployer: SignerWithAddress;
+  let pauser: SignerWithAddress;
+
+  before(async () => {
+    pausableExtMockFactory = await ethers.getContractFactory(
+      "contracts/mocks/access-control/PausableExtUpgradeableMock.sol:PausableExtUpgradeableMock");
+    [deployer, pauser] = await ethers.getSigners();
+  });
+
+  async function deployPausableExtMock(): Promise<{ pausableExtMock: Contract }> {
+    const pausableExtMock: Contract = await upgrades.deployProxy(pausableExtMockFactory);
+    await pausableExtMock.deployed();
+    return { pausableExtMock };
+  }
+
+  async function deployAndConfigurePausableExtMock(): Promise<{ pausableExtMock: Contract }> {
+    const { pausableExtMock } = await deployPausableExtMock();
+    await proveTx(pausableExtMock.grantRole(pauserRole, pauser.address));
+    return { pausableExtMock };
+  }
+
+  describe("Function 'initialize()'", async () => {
+    it("The external initializer configures the contract as expected", async () => {
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
+
+      //The roles
+      expect((await pausableExtMock.OWNER_ROLE()).toLowerCase()).to.equal(ownerRole);
+      expect((await pausableExtMock.PAUSER_ROLE()).toLowerCase()).to.equal(pauserRole);
+
+      // The role admins
+      expect(await pausableExtMock.getRoleAdmin(ownerRole)).to.equal(ethers.constants.HashZero);
+      expect(await pausableExtMock.getRoleAdmin(pauserRole)).to.equal(ownerRole);
+
+      // The deployer should have the owner role, but not the other roles
+      expect(await pausableExtMock.hasRole(ownerRole, deployer.address)).to.equal(true);
+      expect(await pausableExtMock.hasRole(pauserRole, deployer.address)).to.equal(false);
+
+      // The initial contract state is unpaused
+      expect(await pausableExtMock.paused()).to.equal(false);
+    });
+
+    it("The external initializer is reverted if it is called a second time", async () => {
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
+      await expect(
+        pausableExtMock.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("The internal initializer is reverted if it is called outside the init process", async () => {
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
+      await expect(
+        pausableExtMock.call_parent_initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+
+    it("The internal unchained initializer is reverted if it is called outside the init process", async () => {
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
+      await expect(
+        pausableExtMock.call_parent_initialize_unchained()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+  });
+
+  describe("Function 'pause()'", async () => {
+    it("Executes successfully and emits the correct event", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
+
+      await expect(
+        pausableExtMock.connect(pauser).pause()
+      ).to.emit(
+        pausableExtMock,
+        "Paused"
+      ).withArgs(pauser.address);
+
+      expect(await pausableExtMock.paused()).to.equal(true);
+    });
+
+    it("Is reverted if it is called by an account without the pauser role", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
+      await expect(
+        pausableExtMock.pause()
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, pauserRole));
+    });
+  });
+
+  describe("Function 'unpause()'", async () => {
+    it("Executes successfully and emits the correct event", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
+      await proveTx(pausableExtMock.connect(pauser).pause());
+
+      await expect(
+        pausableExtMock.connect(pauser).unpause()
+      ).to.emit(
+        pausableExtMock,
+        "Unpaused"
+      ).withArgs(pauser.address);
+
+      expect(await pausableExtMock.paused()).to.equal(false);
+    });
+
+    it("Is reverted if it is called by an account without the pauser role", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
+      await expect(
+        pausableExtMock.unpause()
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, pauserRole));
+    });
+  });
+});

--- a/test/access-control/RescuableUpgradeable.test.ts
+++ b/test/access-control/RescuableUpgradeable.test.ts
@@ -1,0 +1,141 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../../test-utils/eth";
+import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'access-control/RescuableUpgradeable'", async () => {
+  const TOKEN_AMOUNT = 123;
+
+  const EVENT_NAME_TRANSFER = "Transfer";
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+
+  const ownerRole: string = ethers.utils.id("OWNER_ROLE");
+  const rescuerRole: string = ethers.utils.id("RESCUER_ROLE");
+
+  let rescuableMockFactory: ContractFactory;
+  let tokenMockFactory: ContractFactory;
+
+  let deployer: SignerWithAddress;
+  let rescuer: SignerWithAddress;
+
+  before(async () => {
+    rescuableMockFactory = await ethers.getContractFactory(
+      "contracts/mocks/access-control/RescuableUpgradeableMock.sol:RescuableUpgradeableMock");
+    tokenMockFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+
+    [deployer, rescuer] = await ethers.getSigners();
+  });
+
+  async function deployRescuableMock(): Promise<{ rescuableMock: Contract }> {
+    const rescuableMock: Contract = await upgrades.deployProxy(rescuableMockFactory);
+    await rescuableMock.deployed();
+    return { rescuableMock };
+  }
+
+  async function deployTokenMock(): Promise<{ tokenMock: Contract }> {
+    const tokenMock: Contract = await upgrades.deployProxy(tokenMockFactory, ["ERC20 Test", "TEST"]);
+    await tokenMock.deployed();
+    return { tokenMock };
+  }
+
+  async function deployAndConfigureAllContracts(): Promise<{ rescuableMock: Contract, tokenMock: Contract }> {
+    const { rescuableMock } = await deployRescuableMock();
+    const { tokenMock } = await deployTokenMock();
+
+    await proveTx(tokenMock.mint(rescuableMock.address, TOKEN_AMOUNT));
+    await proveTx(rescuableMock.grantRole(rescuerRole, rescuer.address));
+
+    return {
+      rescuableMock,
+      tokenMock
+    };
+  }
+
+  describe("Function 'initialize()'", async () => {
+    it("The external initializer configures the contract as expected", async () => {
+      const { rescuableMock } = await setUpFixture(deployRescuableMock);
+
+      //The roles
+      expect((await rescuableMock.OWNER_ROLE()).toLowerCase()).to.equal(ownerRole);
+      expect((await rescuableMock.RESCUER_ROLE()).toLowerCase()).to.equal(rescuerRole);
+
+      // The role admins
+      expect(await rescuableMock.getRoleAdmin(ownerRole)).to.equal(ethers.constants.HashZero);
+      expect(await rescuableMock.getRoleAdmin(rescuerRole)).to.equal(ownerRole);
+
+      // The deployer should have the owner role, but not the other roles
+      expect(await rescuableMock.hasRole(ownerRole, deployer.address)).to.equal(true);
+      expect(await rescuableMock.hasRole(rescuerRole, deployer.address)).to.equal(false);
+    });
+
+    it("The external initializer is reverted if it is called a second time", async () => {
+      const { rescuableMock } = await setUpFixture(deployRescuableMock);
+      await expect(
+        rescuableMock.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("The internal initializer is reverted if it is called outside the init process", async () => {
+      const { rescuableMock } = await setUpFixture(deployRescuableMock);
+      await expect(
+        rescuableMock.call_parent_initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+
+    it("The internal unchained initializer is reverted if it is called outside the init process", async () => {
+      const { rescuableMock } = await setUpFixture(deployRescuableMock);
+      await expect(
+        rescuableMock.call_parent_initialize_unchained()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+  });
+
+  describe("Function 'rescueERC20()'", async () => {
+    it("Executes as expected and emits the correct event", async () => {
+      const { rescuableMock, tokenMock } = await setUpFixture(deployAndConfigureAllContracts);
+
+      await expect(
+        rescuableMock.connect(rescuer).rescueERC20(
+          tokenMock.address,
+          deployer.address,
+          TOKEN_AMOUNT
+        )
+      ).to.changeTokenBalances(
+        tokenMock,
+        [rescuableMock, deployer, rescuer],
+        [-TOKEN_AMOUNT, +TOKEN_AMOUNT, 0]
+      ).and.to.emit(
+        tokenMock,
+        EVENT_NAME_TRANSFER
+      ).withArgs(
+        rescuableMock.address,
+        deployer.address,
+        TOKEN_AMOUNT
+      );
+    });
+
+    it("Is reverted if it is called by an account without the rescuer role", async () => {
+      const { rescuableMock, tokenMock } = await setUpFixture(deployAndConfigureAllContracts);
+      await expect(
+        rescuableMock.rescueERC20(
+          tokenMock.address,
+          deployer.address,
+          TOKEN_AMOUNT
+        )
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, rescuerRole));
+    });
+  });
+});

--- a/test/access-control/WhitelistableUpgradeable.test.ts
+++ b/test/access-control/WhitelistableUpgradeable.test.ts
@@ -1,0 +1,166 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../../test-utils/eth";
+import { createRevertMessageDueToMissingRole } from "../../test-utils/misc";
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'access-control/WhitelistableUpgradeable'", async () => {
+  const EVENT_NAME_WHITELISTED = "Whitelisted";
+  const EVENT_NAME_TEST_ONLY_WHITELISTED_MODIFIER_SUCCEEDED = "TestOnlyWhitelistedModifierSucceeded";
+  const EVENT_NAME_UNWHITELISTED = "UnWhitelisted";
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+
+  const REVERT_ERROR_IF_ACCOUNT_IS_NOT_WHITELISTED = "NotWhitelistedAccount";
+
+  const ownerRole: string = ethers.utils.id("OWNER_ROLE");
+  const whitelisterRole: string = ethers.utils.id("WHITELISTER_ROLE");
+
+  let whitelistableMockFactory: ContractFactory;
+
+  let deployer: SignerWithAddress;
+  let whitelister: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  before(async () => {
+    [deployer, whitelister, user] = await ethers.getSigners();
+    whitelistableMockFactory = await ethers.getContractFactory(
+      "contracts/mocks/access-control/WhitelistableUpgradeableMock.sol:WhitelistableUpgradeableMock");
+  });
+
+  async function deployWhitelistableMock(): Promise<{ whitelistableMock: Contract }> {
+    const whitelistableMock: Contract = await upgrades.deployProxy(whitelistableMockFactory);
+    await whitelistableMock.deployed();
+    return { whitelistableMock };
+  }
+
+  async function deployAndConfigureWhitelistableMock(): Promise<{ whitelistableMock: Contract }> {
+    const { whitelistableMock } = await deployWhitelistableMock();
+    await proveTx(whitelistableMock.grantRole(whitelisterRole, whitelister.address));
+    return { whitelistableMock };
+  }
+
+  describe("Initializers", async () => {
+    it("The external initializer configures the contract as expected", async () => {
+      const { whitelistableMock } = await setUpFixture(deployWhitelistableMock);
+
+      // The roles
+      expect(await whitelistableMock.OWNER_ROLE()).to.equal(ownerRole);
+      expect(await whitelistableMock.WHITELISTER_ROLE()).to.equal(whitelisterRole);
+
+      // The role admins
+      expect(await whitelistableMock.getRoleAdmin(ownerRole)).to.equal(ethers.constants.HashZero);
+      expect(await whitelistableMock.getRoleAdmin(whitelisterRole)).to.equal(ownerRole);
+
+      // The deployer should have the owner role, but not the other roles
+      expect(await whitelistableMock.hasRole(ownerRole, deployer.address)).to.equal(true);
+      expect(await whitelistableMock.hasRole(whitelisterRole, deployer.address)).to.equal(false);
+    });
+
+    it("The external initializer is reverted if it is called a second time", async () => {
+      const { whitelistableMock } = await setUpFixture(deployWhitelistableMock);
+      await expect(
+        whitelistableMock.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("The internal initializer is reverted if it is called outside the init process", async () => {
+      const { whitelistableMock } = await setUpFixture(deployWhitelistableMock);
+      await expect(
+        whitelistableMock.call_parent_initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+
+    it("The internal unchained initializer is reverted if it is called outside the init process", async () => {
+      const { whitelistableMock } = await setUpFixture(deployWhitelistableMock);
+      await expect(
+        whitelistableMock.call_parent_initialize_unchained()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+  });
+
+  describe("Function 'whitelist()'", async () => {
+    it("Executes as expected and emits the correct event if it is called by a whitelister", async () => {
+      const { whitelistableMock } = await setUpFixture(deployAndConfigureWhitelistableMock);
+      expect(await whitelistableMock.isWhitelisted(user.address)).to.equal(false);
+
+      await expect(
+        whitelistableMock.connect(whitelister).whitelist(user.address)
+      ).to.emit(
+        whitelistableMock,
+        EVENT_NAME_WHITELISTED
+      ).withArgs(user.address);
+      expect(await whitelistableMock.isWhitelisted(user.address)).to.equal(true);
+
+      // Second call with the same argument should not emit an event
+      await expect(
+        whitelistableMock.connect(whitelister).whitelist(user.address)
+      ).not.to.emit(whitelistableMock, EVENT_NAME_WHITELISTED);
+    });
+  });
+
+  it("Is reverted if it is called by an account without the whitelister role", async () => {
+    const { whitelistableMock } = await setUpFixture(deployAndConfigureWhitelistableMock);
+    await expect(
+      whitelistableMock.whitelist(user.address)
+    ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, whitelisterRole));
+  });
+
+  describe("Function 'unWhitelist()'", async () => {
+    it("Executes as expected and emits the correct event if it is called by a whitelister", async () => {
+      const { whitelistableMock } = await setUpFixture(deployAndConfigureWhitelistableMock);
+      await proveTx(whitelistableMock.connect(whitelister).whitelist(user.address));
+
+      expect(await whitelistableMock.isWhitelisted(user.address)).to.equal(true);
+
+      await expect(
+        whitelistableMock.connect(whitelister).unWhitelist(user.address)
+      ).to.emit(
+        whitelistableMock,
+        EVENT_NAME_UNWHITELISTED
+      ).withArgs(user.address);
+      expect(await whitelistableMock.isWhitelisted(user.address)).to.equal(false);
+
+      // The second call with the same argument should not emit an event
+      await expect(
+        whitelistableMock.connect(whitelister).unWhitelist(user.address)
+      ).not.to.emit(whitelistableMock, EVENT_NAME_UNWHITELISTED);
+    });
+
+    it("Is reverted if it is called by an account without the whitelister role", async () => {
+      const { whitelistableMock } = await setUpFixture(deployAndConfigureWhitelistableMock);
+      await expect(
+        whitelistableMock.unWhitelist(user.address)
+      ).to.be.revertedWith(createRevertMessageDueToMissingRole(deployer.address, whitelisterRole));
+    });
+  });
+
+  describe("Modifier 'onlyWhitelisted'", async () => {
+    it("Reverts the target function if the caller is not whitelisted", async () => {
+      const { whitelistableMock } = await setUpFixture(deployAndConfigureWhitelistableMock);
+      await expect(
+        whitelistableMock.testOnlyWhitelistedModifier()
+      ).to.be.revertedWithCustomError(whitelistableMock, REVERT_ERROR_IF_ACCOUNT_IS_NOT_WHITELISTED);
+    });
+
+    it("Does not revert the target function if the caller is whitelisted", async () => {
+      const { whitelistableMock } = await setUpFixture(deployAndConfigureWhitelistableMock);
+      await proveTx(whitelistableMock.connect(whitelister).whitelist(deployer.address));
+
+      await expect(
+        whitelistableMock.testOnlyWhitelistedModifier()
+      ).to.emit(whitelistableMock, EVENT_NAME_TEST_ONLY_WHITELISTED_MODIFIER_SUCCEEDED);
+    });
+  });
+});

--- a/test/access-ownable/BlacklistableUpgradeable.test.ts
+++ b/test/access-ownable/BlacklistableUpgradeable.test.ts
@@ -1,0 +1,209 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../../test-utils/eth";
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'access-ownable/BlacklistableUpgradeable'", async () => {
+  const EVENT_NAME_BLACKLISTED = "Blacklisted";
+  const EVENT_NAME_BLACKLISTER_CHANGED = "BlacklisterChanged";
+  const EVENT_NAME_SELFBLACKLISTED = "SelfBlacklisted";
+  const EVENT_NAME_TEST_NOT_BLACKLISTED_MODIFIER_SUCCEEDED = "TestNotBlacklistedModifierSucceeded";
+  const EVENT_NAME_UNBLACKLISTED = "UnBlacklisted";
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+
+  const REVERT_ERROR_IF_CALLER_IS_NOT_BLACKLISTER = "UnauthorizedBlacklister";
+  const REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED = "BlacklistedAccount";
+
+  let blacklistableMockFactory: ContractFactory;
+
+  let deployer: SignerWithAddress;
+  let blacklister: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  before(async () => {
+    [deployer, blacklister, user] = await ethers.getSigners();
+    blacklistableMockFactory = await ethers.getContractFactory(
+      "contracts/mocks/access-ownable/BlacklistableUpgradeableMock.sol:BlacklistableUpgradeableMock");
+  });
+
+  async function deployBlacklistableMock(): Promise<{ blacklistableMock: Contract }> {
+    const blacklistableMock: Contract = await upgrades.deployProxy(blacklistableMockFactory);
+    await blacklistableMock.deployed();
+    return { blacklistableMock };
+  }
+
+  async function deployAndConfigureBlacklistableMock(): Promise<{ blacklistableMock: Contract }> {
+    const { blacklistableMock } = await deployBlacklistableMock();
+    await proveTx(blacklistableMock.setBlacklister(blacklister.address));
+    return { blacklistableMock };
+  }
+
+  describe("Initializers", async () => {
+    it("The external initializer configures the contract as expected", async () => {
+      const { blacklistableMock } = await setUpFixture(deployBlacklistableMock);
+      expect(await blacklistableMock.owner()).to.equal(deployer.address);
+      expect(await blacklistableMock.blacklister()).to.equal(ethers.constants.AddressZero);
+    });
+
+    it("The external initializer is reverted if it is called a second time", async () => {
+      const { blacklistableMock } = await setUpFixture(deployBlacklistableMock);
+      await expect(
+        blacklistableMock.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("The internal initializer is reverted if it is called outside the init process", async () => {
+      const { blacklistableMock } = await setUpFixture(deployBlacklistableMock);
+      await expect(
+        blacklistableMock.call_parent_initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+
+    it("The internal unchained initializer is reverted if it is called outside the init process", async () => {
+      const { blacklistableMock } = await setUpFixture(deployBlacklistableMock);
+      await expect(
+        blacklistableMock.call_parent_initialize_unchained()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+  });
+
+  describe("Function 'setBlacklister()'", async () => {
+    it("Executes as expected and emits the correct event", async () => {
+      const { blacklistableMock } = await setUpFixture(deployBlacklistableMock);
+
+      await expect(
+        blacklistableMock.setBlacklister(blacklister.address)
+      ).to.emit(
+        blacklistableMock,
+        EVENT_NAME_BLACKLISTER_CHANGED
+      ).withArgs(blacklister.address);
+      expect(await blacklistableMock.blacklister()).to.equal(blacklister.address);
+
+      // The second call with the same argument should not emit an event
+      await expect(
+        blacklistableMock.setBlacklister(blacklister.address)
+      ).not.to.emit(blacklistableMock, EVENT_NAME_BLACKLISTER_CHANGED);
+    });
+
+    it("Is reverted if it is called not by the owner", async () => {
+      const { blacklistableMock } = await setUpFixture(deployBlacklistableMock);
+      await expect(
+        blacklistableMock.connect(blacklister).setBlacklister(blacklister.address)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+  });
+
+  describe("Function 'blacklist()'", async () => {
+    it("Executes as expected and emits the correct event if it is called by the blacklister", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+      expect(await blacklistableMock.isBlacklisted(user.address)).to.equal(false);
+
+      await expect(
+        blacklistableMock.connect(blacklister).blacklist(user.address)
+      ).to.emit(
+        blacklistableMock,
+        EVENT_NAME_BLACKLISTED
+      ).withArgs(user.address);
+      expect(await blacklistableMock.isBlacklisted(user.address)).to.equal(true);
+
+      // The second call with the same argument should not emit an event
+      await expect(
+        blacklistableMock.connect(blacklister).blacklist(user.address)
+      ).not.to.emit(blacklistableMock, EVENT_NAME_BLACKLISTED);
+    });
+
+    it("Is reverted if it is called not by the blacklister", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+      await expect(
+        blacklistableMock.blacklist(user.address)
+      ).to.be.revertedWithCustomError(blacklistableMock, REVERT_ERROR_IF_CALLER_IS_NOT_BLACKLISTER);
+    });
+  });
+
+  describe("Function 'unBlacklist()'", async () => {
+    it("Executes as expected and emits the correct event if it is called by the blacklister", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+      await proveTx(blacklistableMock.connect(blacklister).blacklist(user.address));
+      expect(await blacklistableMock.isBlacklisted(user.address)).to.equal(true);
+
+      await expect(
+        blacklistableMock.connect(blacklister).unBlacklist(user.address)
+      ).to.emit(
+        blacklistableMock,
+        EVENT_NAME_UNBLACKLISTED
+      ).withArgs(user.address);
+      expect(await blacklistableMock.isBlacklisted(user.address)).to.equal(false);
+
+      // The second call with the same argument should not emit an event
+      await expect(
+        blacklistableMock.connect(blacklister).unBlacklist(user.address)
+      ).not.to.emit(blacklistableMock, EVENT_NAME_UNBLACKLISTED);
+    });
+
+    it("Is reverted if it is called not by the blacklister", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+      await expect(
+        blacklistableMock.unBlacklist(user.address)
+      ).to.be.revertedWithCustomError(blacklistableMock, REVERT_ERROR_IF_CALLER_IS_NOT_BLACKLISTER);
+    });
+  });
+
+  describe("Function 'selfBlacklist()'", async () => {
+    it("Executes as expected and emits the correct events if it is called by any account", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+      expect(await blacklistableMock.isBlacklisted(user.address)).to.equal(false);
+
+      await expect(
+        blacklistableMock.connect(user).selfBlacklist()
+      ).to.emit(
+        blacklistableMock,
+        EVENT_NAME_BLACKLISTED
+      ).withArgs(
+        user.address
+      ).and.to.emit(
+        blacklistableMock,
+        EVENT_NAME_SELFBLACKLISTED
+      ).withArgs(
+        user.address
+      );
+
+      expect(await blacklistableMock.isBlacklisted(user.address)).to.equal(true);
+
+      // The second call should not emit an event
+      await expect(
+        blacklistableMock.connect(user).selfBlacklist()
+      ).not.to.emit(blacklistableMock, EVENT_NAME_SELFBLACKLISTED);
+    });
+  });
+
+  describe("Modifier 'notBlacklisted'", async () => {
+    it("Reverts the target function if the caller is blacklisted", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+      await proveTx(blacklistableMock.connect(blacklister).blacklist(deployer.address));
+
+      await expect(
+        blacklistableMock.testNotBlacklistedModifier()
+      ).to.be.revertedWithCustomError(blacklistableMock, REVERT_ERROR_IF_ACCOUNT_IS_BLACKLISTED);
+    });
+
+    it("Does not revert the target function if the caller is not blacklisted", async () => {
+      const { blacklistableMock } = await setUpFixture(deployAndConfigureBlacklistableMock);
+      await expect(
+        blacklistableMock.connect(user).testNotBlacklistedModifier()
+      ).to.emit(blacklistableMock, EVENT_NAME_TEST_NOT_BLACKLISTED_MODIFIER_SUCCEEDED);
+    });
+  });
+});

--- a/test/access-ownable/PausableExtUpgradeable.test.ts
+++ b/test/access-ownable/PausableExtUpgradeable.test.ts
@@ -1,0 +1,153 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../../test-utils/eth";
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'access-ownable/PausableExtUpgradeable'", async () => {
+  const EVENT_NAME_PAUSED = "Paused";
+  const EVENT_NAME_PAUSER_CHANGED = "PauserChanged";
+  const EVENT_NAME_UNPAUSED = "Unpaused";
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+
+  const REVERT_ERROR_IF_CALLER_IS_NOT_PAUSER = "UnauthorizedPauser";
+
+  let pausableExtMockFactory: ContractFactory;
+
+  let deployer: SignerWithAddress;
+  let pauser: SignerWithAddress;
+
+  before(async () => {
+    pausableExtMockFactory = await ethers.getContractFactory(
+      "contracts/mocks/access-ownable/PausableExtUpgradeableMock.sol:PausableExtUpgradeableMock");
+    [deployer, pauser] = await ethers.getSigners();
+  });
+
+  async function deployPausableExtMock(): Promise<{ pausableExtMock: Contract }> {
+    const pausableExtMock: Contract = await upgrades.deployProxy(pausableExtMockFactory);
+    await pausableExtMock.deployed();
+    return { pausableExtMock };
+  }
+
+  async function deployAndConfigurePausableExtMock(): Promise<{ pausableExtMock: Contract }> {
+    const { pausableExtMock } = await deployPausableExtMock();
+    await proveTx(pausableExtMock.setPauser(pauser.address));
+    return { pausableExtMock };
+  }
+
+  describe("Function 'initialize()'", async () => {
+    it("The external initializer configures the contract as expected", async () => {
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
+
+      expect(await pausableExtMock.owner()).to.equal(deployer.address);
+      expect(await pausableExtMock.pauser()).to.equal(ethers.constants.AddressZero);
+
+      // The initial contract state is unpaused
+      expect(await pausableExtMock.paused()).to.equal(false);
+    });
+
+    it("The external initializer is reverted if it is called a second time", async () => {
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
+      await expect(
+        pausableExtMock.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("The internal initializer is reverted if it is called outside the init process", async () => {
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
+      await expect(
+        pausableExtMock.call_parent_initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+
+    it("The internal unchained initializer is reverted if it is called outside the init process", async () => {
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
+      await expect(
+        pausableExtMock.call_parent_initialize_unchained()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+  });
+
+  describe("Function 'setPauser()'", async () => {
+    it("Executes successfully and emits the correct event", async () => {
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
+
+      await expect(
+        pausableExtMock.setPauser(pauser.address)
+      ).to.emit(
+        pausableExtMock,
+        EVENT_NAME_PAUSER_CHANGED
+      ).withArgs(pauser.address);
+      expect(await pausableExtMock.pauser()).to.equal(pauser.address);
+
+      // The second call with the same argument should not emit an event
+      await expect(
+        pausableExtMock.setPauser(pauser.address)
+      ).not.to.emit(pausableExtMock, EVENT_NAME_PAUSER_CHANGED);
+    });
+
+    it("Is reverted if it is called not by the owner", async () => {
+      const { pausableExtMock } = await setUpFixture(deployPausableExtMock);
+      await expect(
+        pausableExtMock.connect(pauser).setPauser(pauser.address)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+  });
+
+  describe("Function 'pause()'", async () => {
+    it("Executes successfully and emits the correct event", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
+
+      await expect(
+        pausableExtMock.connect(pauser).pause()
+      ).to.emit(
+        pausableExtMock,
+        EVENT_NAME_PAUSED
+      ).withArgs(pauser.address);
+
+      expect(await pausableExtMock.paused()).to.equal(true);
+    });
+
+    it("Is reverted if it is called not by the pauser", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
+      await expect(
+        pausableExtMock.pause()
+      ).to.be.revertedWithCustomError(pausableExtMock, REVERT_ERROR_IF_CALLER_IS_NOT_PAUSER);
+    });
+  });
+
+  describe("Function 'unpause()'", async () => {
+    it("Executes successfully and emits the correct event", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
+      await proveTx(pausableExtMock.connect(pauser).pause());
+
+      await expect(
+        pausableExtMock.connect(pauser).unpause()
+      ).to.emit(
+        pausableExtMock,
+        EVENT_NAME_UNPAUSED
+      ).withArgs(pauser.address);
+
+      expect(await pausableExtMock.paused()).to.equal(false);
+    });
+
+    it("Is reverted if it is called not by the pauser", async () => {
+      const { pausableExtMock } = await setUpFixture(deployAndConfigurePausableExtMock);
+      await expect(
+        pausableExtMock.unpause()
+      ).to.be.revertedWithCustomError(pausableExtMock, REVERT_ERROR_IF_CALLER_IS_NOT_PAUSER);
+    });
+  });
+});

--- a/test/access-ownable/RescuableUpgradeable.test.ts
+++ b/test/access-ownable/RescuableUpgradeable.test.ts
@@ -1,0 +1,156 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../../test-utils/eth";
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'access-ownable/RescuableUpgradeable'", async () => {
+  const TOKEN_AMOUNT = 123;
+
+  const EVENT_NAME_RESCUER_CHANGED = "RescuerChanged";
+  const EVENT_NAME_TRANSFER = "Transfer";
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+
+  const REVERT_ERROR_IF_CALLER_IS_NOT_RESCUER = "UnauthorizedRescuer";
+
+  let rescuableMockFactory: ContractFactory;
+  let tokenMockFactory: ContractFactory;
+
+  let deployer: SignerWithAddress;
+  let rescuer: SignerWithAddress;
+
+  before(async () => {
+    rescuableMockFactory = await ethers.getContractFactory(
+      "contracts/mocks/access-ownable/RescuableUpgradeableMock.sol:RescuableUpgradeableMock");
+    tokenMockFactory = await ethers.getContractFactory("ERC20UpgradeableMock");
+    [deployer, rescuer] = await ethers.getSigners();
+  });
+
+  async function deployRescuableMock(): Promise<{ rescuableMock: Contract }> {
+    const rescuableMock: Contract = await upgrades.deployProxy(rescuableMockFactory);
+    await rescuableMock.deployed();
+    return { rescuableMock };
+  }
+
+  async function deployTokenMock(): Promise<{ tokenMock: Contract }> {
+    const tokenMock: Contract = await upgrades.deployProxy(tokenMockFactory, ["ERC20 Test", "TEST"]);
+    await tokenMock.deployed();
+    return { tokenMock };
+  }
+
+  async function deployAndConfigureAllContracts(): Promise<{ rescuableMock: Contract, tokenMock: Contract }> {
+    const { rescuableMock } = await deployRescuableMock();
+    const { tokenMock } = await deployTokenMock();
+
+    await proveTx(tokenMock.mint(rescuableMock.address, TOKEN_AMOUNT));
+    await proveTx(rescuableMock.setRescuer(rescuer.address));
+
+    return {
+      rescuableMock,
+      tokenMock
+    };
+  }
+
+  describe("Function 'initialize()'", async () => {
+    it("The external initializer configures the contract as expected", async () => {
+      const { rescuableMock } = await setUpFixture(deployRescuableMock);
+
+      expect(await rescuableMock.owner()).to.equal(deployer.address);
+      expect(await rescuableMock.rescuer()).to.equal(ethers.constants.AddressZero);
+    });
+
+    it("The external initializer is reverted if it is called a second time", async () => {
+      const { rescuableMock } = await setUpFixture(deployRescuableMock);
+      await expect(
+        rescuableMock.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("The internal initializer is reverted if it is called outside the init process", async () => {
+      const { rescuableMock } = await setUpFixture(deployRescuableMock);
+      await expect(
+        rescuableMock.call_parent_initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+
+    it("The internal unchained initializer is reverted if it is called outside the init process", async () => {
+      const { rescuableMock } = await setUpFixture(deployRescuableMock);
+      await expect(
+        rescuableMock.call_parent_initialize_unchained()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+  });
+
+  describe("Function 'setRescuer()'", async () => {
+    it("Executes successfully and emits the correct event if it is called by the owner", async () => {
+      const { rescuableMock } = await setUpFixture(deployRescuableMock);
+      await expect(
+        rescuableMock.setRescuer(rescuer.address)
+      ).to.emit(
+        rescuableMock,
+        EVENT_NAME_RESCUER_CHANGED
+      ).withArgs(rescuer.address);
+      expect(await rescuableMock.rescuer()).to.equal(rescuer.address);
+
+      // The second call with the same argument should not emit an event
+      await expect(
+        rescuableMock.setRescuer(rescuer.address)
+      ).not.to.emit(rescuableMock, EVENT_NAME_RESCUER_CHANGED);
+    });
+
+    it("Is reverted if it is called not by the owner", async () => {
+      const { rescuableMock } = await setUpFixture(deployRescuableMock);
+      await expect(
+        rescuableMock.connect(rescuer).setRescuer(rescuer.address)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+  });
+
+  describe("Function 'rescueERC20()'", async () => {
+    it("Executes as expected and emits the correct event", async () => {
+      const { rescuableMock, tokenMock } = await setUpFixture(deployAndConfigureAllContracts);
+
+      await expect(
+        rescuableMock.connect(rescuer).rescueERC20(
+          tokenMock.address,
+          deployer.address,
+          TOKEN_AMOUNT
+        )
+      ).to.changeTokenBalances(
+        tokenMock,
+        [rescuableMock, deployer, rescuer],
+        [-TOKEN_AMOUNT, +TOKEN_AMOUNT, 0]
+      ).and.to.emit(
+        tokenMock,
+        EVENT_NAME_TRANSFER
+      ).withArgs(
+        rescuableMock.address,
+        deployer.address,
+        TOKEN_AMOUNT
+      );
+    });
+
+    it("Is reverted if it is called not by the rescuer", async () => {
+      const { rescuableMock, tokenMock } = await setUpFixture(deployAndConfigureAllContracts);
+      await expect(
+        rescuableMock.rescueERC20(
+          tokenMock.address,
+          deployer.address,
+          TOKEN_AMOUNT
+        )
+      ).to.be.revertedWithCustomError(rescuableMock, REVERT_ERROR_IF_CALLER_IS_NOT_RESCUER);
+    });
+  });
+});

--- a/test/access-ownable/WhitelistableUpgradeable.test.ts
+++ b/test/access-ownable/WhitelistableUpgradeable.test.ts
@@ -1,0 +1,180 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { proveTx } from "../../test-utils/eth";
+
+async function setUpFixture(func: any) {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contract 'access-ownable/WhitelistableUpgradeable'", async () => {
+  const EVENT_NAME_WHITELISTED = "Whitelisted";
+  const EVENT_NAME_WHITELISTER_CHANGED = "WhitelisterChanged";
+  const EVENT_NAME_TEST_ONLY_WHITELISTED_MODIFIER_SUCCEEDED = "TestOnlyWhitelistedModifierSucceeded";
+  const EVENT_NAME_UNWHITELISTED = "UnWhitelisted";
+
+  const REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED = "Initializable: contract is already initialized";
+  const REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING = "Initializable: contract is not initializing";
+  const REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER = "Ownable: caller is not the owner";
+
+  const REVERT_ERROR_IF_CALLER_IS_NOT_WHITELISTER = "UnauthorizedWhitelister";
+  const REVERT_ERROR_IF_ACCOUNT_IS_NOT_WHITELISTED = "NotWhitelistedAccount";
+
+  let whitelistableMockFactory: ContractFactory;
+
+  let deployer: SignerWithAddress;
+  let whitelister: SignerWithAddress;
+  let user: SignerWithAddress;
+
+  before(async () => {
+    [deployer, whitelister, user] = await ethers.getSigners();
+    whitelistableMockFactory = await ethers.getContractFactory(
+      "contracts/mocks/access-ownable/WhitelistableUpgradeableMock.sol:WhitelistableUpgradeableMock");
+  });
+
+  async function deployWhitelistableMock(): Promise<{ whitelistableMock: Contract }> {
+    const whitelistableMock: Contract = await upgrades.deployProxy(whitelistableMockFactory);
+    await whitelistableMock.deployed();
+    return { whitelistableMock };
+  }
+
+  async function deployAndConfigureWhitelistableMock(): Promise<{ whitelistableMock: Contract }> {
+    const { whitelistableMock } = await deployWhitelistableMock();
+    await proveTx(whitelistableMock.setWhitelister(whitelister.address));
+    return { whitelistableMock };
+  }
+
+  describe("Initializers", async () => {
+    it("The external initializer configures the contract as expected", async () => {
+      const { whitelistableMock } = await setUpFixture(deployWhitelistableMock);
+      expect(await whitelistableMock.owner()).to.equal(deployer.address);
+      expect(await whitelistableMock.whitelister()).to.equal(ethers.constants.AddressZero);
+    });
+
+    it("The external initializer is reverted if it is called a second time", async () => {
+      const { whitelistableMock } = await setUpFixture(deployWhitelistableMock);
+      await expect(
+        whitelistableMock.initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_ALREADY_INITIALIZED);
+    });
+
+    it("The internal initializer is reverted if it is called outside the init process", async () => {
+      const { whitelistableMock } = await setUpFixture(deployWhitelistableMock);
+      await expect(
+        whitelistableMock.call_parent_initialize()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+
+    it("The internal unchained initializer is reverted if it is called outside the init process", async () => {
+      const { whitelistableMock } = await setUpFixture(deployWhitelistableMock);
+      await expect(
+        whitelistableMock.call_parent_initialize_unchained()
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CONTRACT_IS_NOT_INITIALIZING);
+    });
+  });
+
+  describe("Function 'setWhitelister()'", async () => {
+    it("Executes as expected and emits the correct event", async () => {
+      const { whitelistableMock } = await setUpFixture(deployWhitelistableMock);
+
+      await expect(
+        whitelistableMock.setWhitelister(whitelister.address)
+      ).to.emit(
+        whitelistableMock,
+        EVENT_NAME_WHITELISTER_CHANGED
+      ).withArgs(whitelister.address);
+      expect(await whitelistableMock.whitelister()).to.equal(whitelister.address);
+
+      // The second call with the same argument should not emit an event
+      await expect(
+        whitelistableMock.setWhitelister(whitelister.address)
+      ).not.to.emit(whitelistableMock, EVENT_NAME_WHITELISTER_CHANGED);
+    });
+
+    it("Is reverted if it is called not by the owner", async () => {
+      const { whitelistableMock } = await setUpFixture(deployWhitelistableMock);
+      await expect(
+        whitelistableMock.connect(whitelister).setWhitelister(whitelister.address)
+      ).to.be.revertedWith(REVERT_MESSAGE_IF_CALLER_IS_NOT_OWNER);
+    });
+  });
+
+  describe("Function 'whitelist()'", async () => {
+    it("Executes as expected and emits the correct event if it is called by the whitelister", async () => {
+      const { whitelistableMock } = await setUpFixture(deployAndConfigureWhitelistableMock);
+      expect(await whitelistableMock.isWhitelisted(user.address)).to.equal(false);
+
+      await expect(
+        whitelistableMock.connect(whitelister).whitelist(user.address)
+      ).to.emit(
+        whitelistableMock,
+        EVENT_NAME_WHITELISTED
+      ).withArgs(user.address);
+      expect(await whitelistableMock.isWhitelisted(user.address)).to.equal(true);
+
+      // The second call with the same argument should not emit an event
+      await expect(
+        whitelistableMock.connect(whitelister).whitelist(user.address)
+      ).not.to.emit(whitelistableMock, EVENT_NAME_WHITELISTED);
+    });
+
+    it("Is reverted if it is called not by the whitelister", async () => {
+      const { whitelistableMock } = await setUpFixture(deployAndConfigureWhitelistableMock);
+      await expect(
+        whitelistableMock.whitelist(user.address)
+      ).to.be.revertedWithCustomError(whitelistableMock, REVERT_ERROR_IF_CALLER_IS_NOT_WHITELISTER);
+    });
+  });
+
+  describe("Function 'unWhitelist()'", async () => {
+    it("Executes as expected and emits the correct event if it is called by the whitelister", async () => {
+      const { whitelistableMock } = await setUpFixture(deployAndConfigureWhitelistableMock);
+      await proveTx(whitelistableMock.connect(whitelister).whitelist(user.address));
+      expect(await whitelistableMock.isWhitelisted(user.address)).to.equal(true);
+
+      await expect(
+        whitelistableMock.connect(whitelister).unWhitelist(user.address)
+      ).to.emit(
+        whitelistableMock,
+        EVENT_NAME_UNWHITELISTED
+      ).withArgs(user.address);
+      expect(await whitelistableMock.isWhitelisted(user.address)).to.equal(false);
+
+      // The second call with the same argument should not emit an event
+      await expect(
+        whitelistableMock.connect(whitelister).unWhitelist(user.address)
+      ).not.to.emit(whitelistableMock, EVENT_NAME_UNWHITELISTED);
+    });
+
+    it("Is reverted if it is called not by the whitelister", async () => {
+      const { whitelistableMock } = await setUpFixture(deployAndConfigureWhitelistableMock);
+      await expect(
+        whitelistableMock.unWhitelist(user.address)
+      ).to.be.revertedWithCustomError(whitelistableMock, REVERT_ERROR_IF_CALLER_IS_NOT_WHITELISTER);
+    });
+  });
+
+  describe("Modifier 'onlyWhitelisted'", async () => {
+    it("Reverts the target function if the caller is not whitelisted", async () => {
+      const { whitelistableMock } = await setUpFixture(deployAndConfigureWhitelistableMock);
+      await expect(
+        whitelistableMock.testOnlyWhitelistedModifier()
+      ).to.be.revertedWithCustomError(whitelistableMock, REVERT_ERROR_IF_ACCOUNT_IS_NOT_WHITELISTED);
+    });
+
+    it("Does not revert the target function if the caller is whitelisted", async () => {
+      const { whitelistableMock } = await setUpFixture(deployAndConfigureWhitelistableMock);
+      await proveTx(whitelistableMock.connect(whitelister).whitelist(deployer.address));
+
+      await expect(
+        whitelistableMock.testOnlyWhitelistedModifier()
+      ).to.emit(whitelistableMock, EVENT_NAME_TEST_ONLY_WHITELISTED_MODIFIER_SUCCEEDED);
+    });
+  });
+});


### PR DESCRIPTION
### About

The `BRLC-contracts` package introduces base contracts for CloudWalk projects.
The contracts can be directly imported from the node package manager (NPM) and used in future development.

### List of Contracts
1. `BlacklistableUpgradeable` - Allows to blacklist and unblacklist accounts. It makes available the `notBlacklisted` modifier, which can be applied to functions to restrict their usage to not blacklisted accounts only.

2. `PausableExtUpgradeable` - Extends OpenZeppelin's `PausableUpgradeable` contract and introduces the `pauser` role to pause and unpause the execution of the contract.

3. `RescuableUpgradeable` - Allows to rescue tokens locked up in the contract by transferring them to a specified address.

4. `WhitelistableUpgradeable` - Allows to whitelist and unwhitelist accounts. It makes available the modifier `onlyWhitelisted`, which can be applied to functions to restrict their usage to whitelisted accounts only.

5. `StoragePlaceholderN` - Reserves N storage slots and allows future replacement of it with other contracts without shifting down storage in the inheritance chain.

There are also mock contracts for testing purposes.

### Description of Contracts

All contracts are upgradeable. See https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.

Contracts from 1 to 4 in the list above have two versions:
* role-based;
* owner-based.

The role-based contracts are placed in the `contracts/access-control` directory. They are based on OpenZeppelin's `AccessControlUpgradeable` contract and introduce special roles (`BLACKLISTER_ROLE`, `PAUSER_ROLE`, `RESCUER_ROLE`, `WHITELISTER_ROLE`) for accounts that are allowed to execute the main function of the contract.
E.g. in the `BlacklistableUpgradeable` contract only accounts with the `BLACKLISTER_ROLE` role can blacklist and unblacklist other accounts.
The admin role of a specific role is configured through the argument of the initialize function.

The owner-based contracts are placed in the `contracts/access-ownable` directory. They are based on OpenZeppelin's `OwnableUpgradeable` contract and introduce special accounts (`blacklister`, `pauser`, `rescuer`, `whitelister`) that is allowed to execute the main function of the contract. E.g. in the `BlacklistableUpgradeable` contract only the `blacklister` account can blacklist and unblacklist other accounts.
The special account is the zero address by default and can be changed by the owner of the contract.

Each contract from 1 to 4 in the list above is inherited from the correlative interface.
Interfaces are placed in the `contracts/interface` directory.

### Testing and coverage
All the contracts are 100% covered with tests:
![package-coverage](https://user-images.githubusercontent.com/113507287/212705593-8ddd1bf7-9587-4b5c-8700-f6388b8c5dc5.jpg)
